### PR TITLE
[Xamarin.Build.Download] add appropriate .NET 6 checks (#1000)

### DIFF
--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.targets
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.targets
@@ -10,19 +10,19 @@
 		<XamarinBuildDownloadAllowUnsecure Condition="'$(XamarinBuildDownloadAllowUnsecure)' == ''">false</XamarinBuildDownloadAllowUnsecure>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFrameworkIdentifier)'=='Xamarin.iOS' And ('$(OutputType)' != 'Library' OR '$(IsAppExtension)'=='True')">
+	<PropertyGroup Condition="('$(TargetFrameworkIdentifier)'=='Xamarin.iOS' or '$(TargetPlatformIdentifier)'=='ios') and ('$(OutputType)' != 'Library' or '$(IsAppExtension)'=='True')">
 		<_XamarinBuildDownloadMasterBeforeTargets>GetFrameworkPaths</_XamarinBuildDownloadMasterBeforeTargets>
 		<_XamarinBuildDownloadMasterDependsOnTargets>_XamarinBuildDownload;_XamarinBuildCastAssemblyResources</_XamarinBuildDownloadMasterDependsOnTargets>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFrameworkIdentifier)'=='MonoAndroid'">
+	<PropertyGroup Condition="'$(TargetFrameworkIdentifier)'=='MonoAndroid' or '$(TargetPlatformIdentifier)'=='android'">
 		<_XamarinBuildDownloadIsAndroid>true</_XamarinBuildDownloadIsAndroid>
 		<_XamarinBuildDownloadMasterBeforeTargets>_ResolveLibraryProjectImports</_XamarinBuildDownloadMasterBeforeTargets>
 		<_XamarinBuildDownloadMasterDependsOnTargets>ResolveAssemblyReferences;_XamarinBuildDownload;_XamarinBuildDownloadAarRestore;_XamarinBuildDownloadAarInclude</_XamarinBuildDownloadMasterDependsOnTargets>
 		<_XamarinBuildDownloadAndroidFixManifests Condition="'$(_XamarinBuildDownloadAndroidFixManifests)' == ''">true</_XamarinBuildDownloadAndroidFixManifests>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFrameworkIdentifier)'!='MonoAndroid'">
+	<PropertyGroup Condition="'$(_XamarinBuildDownloadIsAndroid)'==''">
 		<_XamarinBuildDownloadIsAndroid>false</_XamarinBuildDownloadIsAndroid>
 	</PropertyGroup>
 	


### PR DESCRIPTION
Right now Xamarin.Build.Download does not work appropriately in .NET 6
projects. It relies on the value of `$(TargetFrameworkIdentifier)`,
which will be set to `.NETCoreApp` in .NET 6.

To fix this, we can also check if `$(TargetPlatformIdentifer)` is
equal to `ios` or `android`. This should enable Xamarin.Build.Download
to work in .NET 6 projects going forward.

I also tried to fix different casing for `or` and `and` -- to always
use lowercase.